### PR TITLE
Build nuget-native-cli with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build nuget-native-cli
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build nuget-native-cli
+        run: make all
+      - run: ls -lhR bin
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nuget-native-cli
+          path: bin/**


### PR DESCRIPTION
Add GitHub Actions script to build nuget-native-cli

Upload generated executable files as binary attachments to the GitHub Actions job.